### PR TITLE
feat: Add Google Drive video transcription support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,9 @@
 deploy:
 	supabase functions deploy --no-verify-jwt scribe-bot
 
+install:
+	cd supabase/functions/scribe-bot && deno cache index.ts
+
 reload-cache:
 	deno cache --reload ./supabase/functions/scribe-bot/index.ts
 

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ This is a Slack bot that uses the [ElevenLabs Scribe API](https://elevenlabs.io/
 ## Features
 
 - Transcribes audio and video files when mentioned in Slack
+- **NEW:** Supports Google Drive video links for transcription
 - Supports speaker diarization to identify different speakers
 - Automatic timestamp insertion for better navigation
 - Audio event detection (music, laughter, etc.)
@@ -24,6 +25,7 @@ Example:
 ```
 @bot transcribe this file --no-timestamp --no-diarize
 @bot transcribe this file --num-speakers 3
+@bot https://drive.google.com/file/d/xxxxx/view --num-speakers 4
 ```
 
 **Note:** The `--num-speakers` option only works when speaker diarization is enabled (default). If you use `--no-diarize`, the num-speakers setting will be ignored.
@@ -83,6 +85,7 @@ SLACK_SIGNING_SECRET="your-slack-signing-secret"
 SUPABASE_URL="your-supabase-url"
 SUPABASE_SERVICE_ROLE_KEY="your-supabase-service-role-key"
 FUNCTION_SECRET="a-strong-secret-of-your-choice"
+GOOGLE_SERVICE_ACCOUNT_KEY='{"type":"service_account","project_id":"..."}'  # Google service account JSON
 ```
 
 To run the function locally, you can create a `.env.local` file in the root `supabase` directory and run `supabase functions serve --env-file ./supabase/.env.local`.
@@ -136,10 +139,19 @@ The function URL can be found in the output of the `supabase functions deploy` c
 
 ## Usage
 
+### With Slack file uploads:
 1. Upload an audio or video file to a Slack channel
 2. Mention the bot in the same message or as a reply
 3. (Optional) Add transcription options like `--no-timestamp` or `--no-diarize`
 4. The bot will process the file and reply with a transcript text file
+
+### With Google Drive links:
+1. Share a Google Drive video/audio file link in a message
+2. Mention the bot in the same message with the link
+3. (Optional) Add transcription options
+4. The bot will download from Google Drive and transcribe
+
+Example: `@bot https://drive.google.com/file/d/xxxxx/view --num-speakers 3`
 
 ### Supported File Formats
 

--- a/supabase/functions/.env.sample
+++ b/supabase/functions/.env.sample
@@ -4,3 +4,8 @@ ELEVENLABS_API_KEY=your_api_key
 TELEGRAM_BOT_TOKEN=your_bot_token
 # A random secret chosen by you to secure the function.
 FUNCTION_SECRET=random_secret
+# Google service account key JSON for Google Drive access
+GOOGLE_SERVICE_ACCOUNT_KEY=your_service_account_json
+# (Optional) Email address to impersonate for accessing organization-restricted Google Drive files
+# Requires Domain-wide Delegation to be configured in Google Workspace Admin Console
+GOOGLE_IMPERSONATE_EMAIL=user@yourorganization.com

--- a/supabase/functions/scribe-bot/deno.json
+++ b/supabase/functions/scribe-bot/deno.json
@@ -1,6 +1,5 @@
 {
-  "npm": true,
-  "unstable": true,
+  "unstable": ["kv", "temporal"],
   "compilerOptions": {
     "lib": ["dom", "deno.ns"]
   }

--- a/supabase/functions/scribe-bot/deno.lock
+++ b/supabase/functions/scribe-bot/deno.lock
@@ -10,6 +10,9 @@
     "npm:@supabase/realtime-js@2.11.10": "2.11.10",
     "npm:@supabase/storage-js@2.7.1": "2.7.1",
     "npm:elevenlabs@1.50.5": "1.50.5",
+    "npm:elevenlabs@1.59.0": "1.59.0",
+    "npm:google-auth-library@9.15.0": "9.15.0",
+    "npm:googleapis@144.0.0": "144.0.0",
     "npm:openai@^4.52.5": "4.104.0"
   },
   "jsr": {
@@ -105,6 +108,9 @@
         "event-target-shim"
       ]
     },
+    "agent-base@7.1.4": {
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ=="
+    },
     "agentkeepalive@4.6.0": {
       "integrity": "sha512-kja8j7PjmncONqaTsB8fQ+wE2mSU2DJ9D4XKoJ5PFWIdRMa6SLSN1ff4mOr4jCbfRSsxR4keIiySJU0N9T5hIQ==",
       "dependencies": [
@@ -116,6 +122,12 @@
     },
     "base64-js@1.5.1": {
       "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="
+    },
+    "bignumber.js@9.3.1": {
+      "integrity": "sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ=="
+    },
+    "buffer-equal-constant-time@1.0.1": {
+      "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA=="
     },
     "buffer@6.0.3": {
       "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
@@ -155,6 +167,12 @@
         "which"
       ]
     },
+    "debug@4.4.1": {
+      "integrity": "sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ==",
+      "dependencies": [
+        "ms"
+      ]
+    },
     "delayed-stream@1.0.0": {
       "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ=="
     },
@@ -166,8 +184,29 @@
         "gopd"
       ]
     },
+    "ecdsa-sig-formatter@1.0.11": {
+      "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
+      "dependencies": [
+        "safe-buffer"
+      ]
+    },
     "elevenlabs@1.50.5": {
       "integrity": "sha512-fXLalGYr0QOv7udy75NL04IjZuj9rcQRGYfixTM+bKfNCCfKLDz+JN0muNiN1eK5s8SPA0LZ+ROwbN00IL0xhg==",
+      "dependencies": [
+        "command-exists",
+        "execa",
+        "form-data",
+        "form-data-encoder@4.1.0",
+        "formdata-node@6.0.3",
+        "node-fetch",
+        "qs",
+        "readable-stream",
+        "url-join"
+      ],
+      "deprecated": true
+    },
+    "elevenlabs@1.59.0": {
+      "integrity": "sha512-OVKOd+lxNya8h4Rn5fcjv00Asd+DGWfTT6opGrQ16sTI+1HwdLn/kYtjl8tRMhDXbNmksD/9SBRKjb9neiUuVg==",
       "dependencies": [
         "command-exists",
         "execa",
@@ -222,6 +261,9 @@
         "strip-final-newline"
       ]
     },
+    "extend@3.0.2": {
+      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="
+    },
     "form-data-encoder@1.7.2": {
       "integrity": "sha512-qfqtYan3rxrnCk1VYaA4H+Ms9xdpPqvLZa6xmMgFvhO32x7/3J/ExcTd6qpxM0vH2GdMI+poehyBZvqfMTto8A=="
     },
@@ -251,6 +293,24 @@
     "function-bind@1.1.2": {
       "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA=="
     },
+    "gaxios@6.7.1": {
+      "integrity": "sha512-LDODD4TMYx7XXdpwxAVRAIAuB0bzv0s+ywFonY46k126qzQHT9ygyoa9tncmOiQmmDrik65UYsEkv3lbfqQ3yQ==",
+      "dependencies": [
+        "extend",
+        "https-proxy-agent",
+        "is-stream",
+        "node-fetch",
+        "uuid"
+      ]
+    },
+    "gcp-metadata@6.1.1": {
+      "integrity": "sha512-a4tiq7E0/5fTjxPAaH4jpjkSv/uCaU2p5KC6HVGrvl0cDjA8iBZv4vv1gyzlmK0ZUKqwpOyQMKzZQe3lTit77A==",
+      "dependencies": [
+        "gaxios",
+        "google-logging-utils",
+        "json-bigint"
+      ]
+    },
     "get-intrinsic@1.3.0": {
       "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
       "dependencies": [
@@ -276,8 +336,47 @@
     "get-stream@6.0.1": {
       "integrity": "sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg=="
     },
+    "google-auth-library@9.15.0": {
+      "integrity": "sha512-7ccSEJFDFO7exFbO6NRyC+xH8/mZ1GZGG2xxx9iHxZWcjUjJpjWxIMw3cofAKcueZ6DATiukmmprD7yavQHOyQ==",
+      "dependencies": [
+        "base64-js",
+        "ecdsa-sig-formatter",
+        "gaxios",
+        "gcp-metadata",
+        "gtoken",
+        "jws"
+      ]
+    },
+    "google-logging-utils@0.0.2": {
+      "integrity": "sha512-NEgUnEcBiP5HrPzufUkBzJOD/Sxsco3rLNo1F1TNf7ieU8ryUzBhqba8r756CjLX7rn3fHl6iLEwPYuqpoKgQQ=="
+    },
+    "googleapis-common@7.2.0": {
+      "integrity": "sha512-/fhDZEJZvOV3X5jmD+fKxMqma5q2Q9nZNSF3kn1F18tpxmA86BcTxAGBQdM0N89Z3bEaIs+HVznSmFJEAmMTjA==",
+      "dependencies": [
+        "extend",
+        "gaxios",
+        "google-auth-library",
+        "qs",
+        "url-template",
+        "uuid"
+      ]
+    },
+    "googleapis@144.0.0": {
+      "integrity": "sha512-ELcWOXtJxjPX4vsKMh+7V+jZvgPwYMlEhQFiu2sa9Qmt5veX8nwXPksOWGGN6Zk4xCiLygUyaz7xGtcMO+Onxw==",
+      "dependencies": [
+        "google-auth-library",
+        "googleapis-common"
+      ]
+    },
     "gopd@1.2.0": {
       "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg=="
+    },
+    "gtoken@7.1.0": {
+      "integrity": "sha512-pCcEwRi+TKpMlxAQObHDQ56KawURgyAf6jtIY046fJ5tIv3zDe/LEIubckAO8fj6JnAxLdmWkUfNyulQ2iKdEw==",
+      "dependencies": [
+        "gaxios",
+        "jws"
+      ]
     },
     "has-symbols@1.1.0": {
       "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ=="
@@ -292,6 +391,13 @@
       "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
       "dependencies": [
         "function-bind"
+      ]
+    },
+    "https-proxy-agent@7.0.6": {
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "dependencies": [
+        "agent-base",
+        "debug"
       ]
     },
     "human-signals@2.1.0": {
@@ -311,6 +417,27 @@
     },
     "isexe@2.0.0": {
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="
+    },
+    "json-bigint@1.0.0": {
+      "integrity": "sha512-SiPv/8VpZuWbvLSMtTDU8hEfrZWg/mH/nV/b4o0CYbSxu1UIQPLdwKOCIyLQX+VIPO5vrLX3i8qtqFyhdPSUSQ==",
+      "dependencies": [
+        "bignumber.js"
+      ]
+    },
+    "jwa@2.0.1": {
+      "integrity": "sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==",
+      "dependencies": [
+        "buffer-equal-constant-time",
+        "ecdsa-sig-formatter",
+        "safe-buffer"
+      ]
+    },
+    "jws@4.0.0": {
+      "integrity": "sha512-KDncfTmOZoOMTFG4mBlG0qUIOlc03fmzH+ru6RgYVZhPkyiy/92Owlt/8UEN+a4TXR1FQetfIpJE8ApdvdVxTg==",
+      "dependencies": [
+        "jwa",
+        "safe-buffer"
+      ]
     },
     "math-intrinsics@1.1.0": {
       "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g=="
@@ -464,6 +591,13 @@
     },
     "url-join@4.0.1": {
       "integrity": "sha512-jk1+QP6ZJqyOiuEI9AEWQfju/nB2Pw466kbA0LEZljHwKeMgd9WrAEgEGxjPDD2+TNbbb37rTyhEfrCXfuKXnA=="
+    },
+    "url-template@2.0.8": {
+      "integrity": "sha512-XdVKMF4SJ0nP/O7XIPB0JwAEuT9lDIYnNsK8yGVe43y0AWoKeJNdv3ZNWh7ksJ6KqQFjOO6ox/VEitLnaVNufw=="
+    },
+    "uuid@9.0.1": {
+      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+      "bin": true
     },
     "web-streams-polyfill@4.0.0-beta.3": {
       "integrity": "sha512-QW95TCTaHmsYfHDybGMwO5IJIM93I/6vTRk+daHTWFPhwh+C8Cg7j7XyKrwrj8Ib6vYXe0ocYNrmzY4xAAN6ug=="

--- a/supabase/functions/scribe-bot/googledrive.ts
+++ b/supabase/functions/scribe-bot/googledrive.ts
@@ -1,0 +1,206 @@
+import { JWT } from "npm:google-auth-library@9.15.0";
+import { google } from "npm:googleapis@144.0.0";
+
+// Types for Google Drive file metadata
+interface GoogleDriveFile {
+  id: string;
+  name: string;
+  mimeType: string;
+  size?: string;
+}
+
+// Parse Google Drive URL to extract file ID
+export function parseGoogleDriveUrl(url: string): string | null {
+  // Handle various Google Drive URL formats
+  const patterns = [
+    /drive\.google\.com\/file\/d\/([a-zA-Z0-9-_]+)/,
+    /drive\.google\.com\/open\?id=([a-zA-Z0-9-_]+)/,
+    /docs\.google\.com\/[a-z]+\/d\/([a-zA-Z0-9-_]+)/,
+    /drive\.google\.com\/uc\?.*id=([a-zA-Z0-9-_]+)/,
+  ];
+
+  for (const pattern of patterns) {
+    const match = url.match(pattern);
+    if (match) {
+      return match[1];
+    }
+  }
+
+  return null;
+}
+
+// Initialize Google Drive client with service account
+function initializeGoogleDriveClient() {
+  const serviceAccountKey = Deno.env.get("GOOGLE_SERVICE_ACCOUNT_KEY");
+  const impersonateEmail = Deno.env.get("GOOGLE_IMPERSONATE_EMAIL"); // Optional: email to impersonate
+  
+  if (!serviceAccountKey) {
+    throw new Error("GOOGLE_SERVICE_ACCOUNT_KEY environment variable is not set");
+  }
+
+  let credentials;
+  try {
+    credentials = JSON.parse(serviceAccountKey);
+  } catch (error) {
+    throw new Error(`Failed to parse GOOGLE_SERVICE_ACCOUNT_KEY: ${error}`);
+  }
+
+  const auth = new JWT({
+    email: credentials.client_email,
+    key: credentials.private_key,
+    scopes: ["https://www.googleapis.com/auth/drive"],  // Match the scope in Admin Console
+    subject: impersonateEmail, // Impersonate a user in the organization (optional)
+  });
+
+  return google.drive({ version: "v3", auth });
+}
+
+// Get file metadata from Google Drive
+export async function getGoogleDriveFileMetadata(fileId: string): Promise<GoogleDriveFile> {
+  const drive = initializeGoogleDriveClient();
+
+  try {
+    const response = await drive.files.get({
+      fileId,
+      fields: "id,name,mimeType,size",
+      supportsAllDrives: true, // Support for shared drives
+    });
+
+    return response.data as GoogleDriveFile;
+  } catch (error: any) {
+    console.error("Google Drive API error details:", {
+      code: error.code,
+      message: error.message,
+      errors: error.errors,
+      fileId: fileId,
+    });
+    
+    if (error.code === 404) {
+      throw new Error(`File not found (ID: ${fileId}). Check if the URL is correct and the file exists.`);
+    }
+    if (error.code === 403) {
+      throw new Error(`Permission denied. The Google Drive API might not be enabled for this project.`);
+    }
+    throw new Error(`Failed to get file metadata: ${error.message}`);
+  }
+}
+
+// Download Google Drive file to temporary path
+export async function downloadGoogleDriveFileToPath(
+  fileId: string,
+  tempPath: string,
+): Promise<void> {
+  const drive = initializeGoogleDriveClient();
+
+  try {
+    // Get file metadata first to check if it's a Google Docs file
+    const metadata = await getGoogleDriveFileMetadata(fileId);
+    
+    // Check if it's a Google Docs/Sheets/Slides file that needs export
+    const exportMimeTypes: Record<string, string> = {
+      "application/vnd.google-apps.document": "application/pdf",
+      "application/vnd.google-apps.spreadsheet": "application/pdf",
+      "application/vnd.google-apps.presentation": "application/pdf",
+      "application/vnd.google-apps.drawing": "application/pdf",
+    };
+
+    let response;
+    
+    if (exportMimeTypes[metadata.mimeType]) {
+      // Export Google Docs files
+      response = await drive.files.export(
+        {
+          fileId,
+          mimeType: exportMimeTypes[metadata.mimeType],
+        },
+        { responseType: "stream" }
+      );
+    } else {
+      // Download regular files
+      response = await drive.files.get(
+        {
+          fileId,
+          alt: "media",
+          supportsAllDrives: true,
+        },
+        { responseType: "stream" }
+      );
+    }
+
+    // Write stream to file
+    const file = await Deno.open(tempPath, {
+      create: true,
+      write: true,
+      truncate: true,
+    });
+
+    try {
+      // Handle Node.js Readable stream
+      const chunks: Uint8Array[] = [];
+      
+      // response.data is a Node.js Readable stream
+      for await (const chunk of response.data as any) {
+        chunks.push(new Uint8Array(chunk));
+      }
+      
+      // Concatenate all chunks
+      const totalLength = chunks.reduce((acc, chunk) => acc + chunk.length, 0);
+      const result = new Uint8Array(totalLength);
+      let offset = 0;
+      for (const chunk of chunks) {
+        result.set(chunk, offset);
+        offset += chunk.length;
+      }
+      
+      await file.write(result);
+    } finally {
+      file.close();
+    }
+  } catch (error: any) {
+    if (error.code === 403) {
+      throw new Error("Access denied. The file might be private or restricted.");
+    }
+    if (error.code === 404) {
+      throw new Error("File not found or you don't have permission to access it.");
+    }
+    throw new Error(`Failed to download file: ${error.message}`);
+  }
+}
+
+// Check if URL is a Google Drive URL
+export function isGoogleDriveUrl(url: string): boolean {
+  return parseGoogleDriveUrl(url) !== null;
+}
+
+// Download Google Drive file and return metadata
+export async function downloadGoogleDriveFile(
+  url: string,
+  tempPath: string,
+): Promise<{ filename: string; mimeType: string }> {
+  const fileId = parseGoogleDriveUrl(url);
+  
+  if (!fileId) {
+    throw new Error("Invalid Google Drive URL");
+  }
+
+  // Get file metadata
+  const metadata = await getGoogleDriveFileMetadata(fileId);
+  
+  // Download file
+  await downloadGoogleDriveFileToPath(fileId, tempPath);
+
+  // For Google Docs files that were exported, adjust the mime type
+  const exportedTypes: Record<string, string> = {
+    "application/vnd.google-apps.document": "application/pdf",
+    "application/vnd.google-apps.spreadsheet": "application/pdf",
+    "application/vnd.google-apps.presentation": "application/pdf",
+    "application/vnd.google-apps.drawing": "application/pdf",
+  };
+
+  const actualMimeType = exportedTypes[metadata.mimeType] || metadata.mimeType;
+
+  return {
+    filename: metadata.name,
+    mimeType: actualMimeType,
+  };
+}

--- a/supabase/functions/scribe-bot/index.ts
+++ b/supabase/functions/scribe-bot/index.ts
@@ -1,8 +1,9 @@
 import "jsr:@supabase/functions-js/edge-runtime.d.ts";
 import { SlackEvent } from "./types.ts";
-import { parseTranscriptionOptions } from "./utils.ts";
+import { parseTranscriptionOptions, extractGoogleDriveUrls } from "./utils.ts";
 import { sendSlackMessage } from "./slack.ts";
 import { transcribeAudioFile } from "./scribe.ts";
+import { downloadGoogleDriveFile } from "./googledrive.ts";
 
 console.log(`Function "elevenlabs-scribe-bot" up and running!`);
 
@@ -33,17 +34,22 @@ async function handleAppMention(event: SlackEvent) {
   console.log("Parsed options:", options);
 
   try {
-    // Check if the mention includes files
-    if (!event.files || event.files.length === 0) {
+    // Check for Google Drive URLs in the message
+    const googleDriveUrls = extractGoogleDriveUrls(event.text || "");
+
+    // Check if the mention includes files or Google Drive URLs
+    if ((!event.files || event.files.length === 0) && googleDriveUrls.length === 0) {
       const usageMessage = `📝 *使い方*\n\n` +
-        `音声または動画ファイルをアップロードしてメンションしてください。\n\n` +
+        `音声または動画ファイルをアップロードしてメンションするか、\n` +
+        `Google Driveのリンクを含めてメンションしてください。\n\n` +
         `*オプション:*\n` +
         `• \`--no-diarize\`: 話者識別を無効化\n` +
         `• \`--no-timestamp\`: タイムスタンプを非表示\n` +
         `• \`--no-audio-events\`: 音声イベント（拍手、音楽など）のタグを無効化\n` +
         `• \`--num-speakers <数>\`: 話者数を指定（デフォルト: 2）\n\n` +
         `*使用例:*\n` +
-        `@文字起こしKUN --no-timestamp --num-speakers 3`;
+        `@文字起こしKUN --no-timestamp --num-speakers 3\n` +
+        `@文字起こしKUN https://drive.google.com/file/d/xxxxx/view`;
 
       return await sendSlackMessage(
         event.channel,
@@ -52,12 +58,104 @@ async function handleAppMention(event: SlackEvent) {
       );
     }
 
-    // Filter and process audio/video files
-    const audioVideoFiles = event.files.filter((file) =>
-      file.mimetype?.startsWith("audio/") || file.mimetype?.startsWith("video/")
-    );
+    // Process Google Drive URLs first
+    for (const driveUrl of googleDriveUrls) {
+      try {
+        // Create temporary file path
+        const tempDir = await Deno.makeTempDir();
+        const tempPath = `${tempDir}/gdrive_${Date.now()}.tmp`;
 
-    if (audioVideoFiles.length === 0) {
+        // Reply that we're processing the Google Drive file
+        await sendSlackMessage(
+          event.channel,
+          `Google Driveファイルを処理中...`,
+          event.ts,
+        );
+
+        // Download and get metadata
+        const { filename, mimeType } = await downloadGoogleDriveFile(driveUrl, tempPath);
+
+        // Check if it's an audio/video file
+        if (!mimeType.startsWith("audio/") && !mimeType.startsWith("video/")) {
+          await sendSlackMessage(
+            event.channel,
+            `Google Driveファイル "${filename}" は音声または動画ファイルではありません。`,
+            event.ts,
+          );
+          // Clean up temp file
+          try {
+            await Deno.remove(tempPath);
+            await Deno.remove(tempDir);
+          } catch {
+            // Ignore cleanup errors
+          }
+          continue;
+        }
+
+        // Prepare option info
+        const optionInfo = [];
+        if (!options.diarize) optionInfo.push("話者識別OFF");
+        if (!options.showTimestamp) optionInfo.push("タイムスタンプOFF");
+        if (!options.tagAudioEvents) optionInfo.push("音声イベントOFF");
+        if (options.diarize && options.numSpeakers && options.numSpeakers !== 2) {
+          optionInfo.push(`話者数: ${options.numSpeakers}`);
+        }
+
+        const optionText = optionInfo.length > 0
+          ? ` (${optionInfo.join(", ")})`
+          : "";
+
+        await sendSlackMessage(
+          event.channel,
+          `Google Driveファイル "${filename}" を受信しました。文字起こし中${optionText}...`,
+          event.ts,
+        );
+
+        // Create file URL for local temp file
+        const fileURL = `file://${tempPath}`;
+
+        // Run transcription in the background
+        EdgeRuntime.waitUntil(
+          transcribeAudioFile({
+            fileURL,
+            fileType: mimeType,
+            duration: 0, // Duration not available from Google Drive
+            channelId: event.channel,
+            timestamp: event.ts,
+            userId: event.user,
+            options,
+            filename,
+            isGoogleDrive: true,
+            tempPath, // Pass temp path for cleanup
+          }),
+        );
+      } catch (error) {
+        console.error("Google Drive processing error:", error);
+        await sendSlackMessage(
+          event.channel,
+          `Google Driveファイルの処理中にエラーが発生しました: ${error instanceof Error ? error.message : "Unknown error"}`,
+          event.ts,
+        );
+      }
+    }
+
+    // Filter and process audio/video files from Slack
+    const audioVideoFiles = event.files?.filter((file) =>
+      file.mimetype?.startsWith("audio/") || file.mimetype?.startsWith("video/")
+    ) || [];
+
+    if (audioVideoFiles.length === 0 && googleDriveUrls.length === 0) {
+      // This case is already handled above
+      return;
+    }
+
+    if (audioVideoFiles.length === 0 && googleDriveUrls.length > 0) {
+      // Already processed Google Drive URLs above
+      return;
+    }
+
+    // Check if uploaded files are audio/video
+    if (event.files && audioVideoFiles.length === 0 && event.files.length > 0) {
       for (const file of event.files) {
         await sendSlackMessage(
           event.channel,

--- a/supabase/functions/scribe-bot/scribe.ts
+++ b/supabase/functions/scribe-bot/scribe.ts
@@ -44,6 +44,8 @@ export async function transcribeAudioFile({
   userId,
   options,
   filename,
+  isGoogleDrive,
+  tempPath,
 }: {
   fileURL: string;
   fileType: string;
@@ -53,6 +55,8 @@ export async function transcribeAudioFile({
   userId: string;
   options: TranscriptionOptions;
   filename?: string;
+  isGoogleDrive?: boolean;
+  tempPath?: string;
 }) {
   let transcript: string | null = null;
   let languageCode: string | null = null;
@@ -63,12 +67,20 @@ export async function transcribeAudioFile({
   console.log("fileType (MIME):", fileType);
   
   try {
-    const tempDir = await Deno.makeTempDir();
-    const fileExtension = getFileExtensionFromMime(fileType);
-    tempFilePath = `${tempDir}/audio_${Date.now()}.${fileExtension}`;
+    // Handle Google Drive files vs Slack files
+    if (isGoogleDrive && tempPath) {
+      // File is already downloaded from Google Drive
+      tempFilePath = tempPath;
+      console.log("Using Google Drive temp file:", tempFilePath);
+    } else {
+      // Download from Slack
+      const tempDir = await Deno.makeTempDir();
+      const fileExtension = getFileExtensionFromMime(fileType);
+      tempFilePath = `${tempDir}/audio_${Date.now()}.${fileExtension}`;
 
-    console.log("downloading file to temp path:", tempFilePath);
-    await downloadSlackFileToPath(fileURL, tempFilePath);
+      console.log("downloading file to temp path:", tempFilePath);
+      await downloadSlackFileToPath(fileURL, tempFilePath);
+    }
 
     const fileInfo = await Deno.stat(tempFilePath);
     const fileSizeMB = fileInfo.size / (1024 * 1024);
@@ -175,7 +187,8 @@ export async function transcribeAudioFile({
       );
     }
   } finally {
-    if (tempFilePath) {
+    if (tempFilePath && !isGoogleDrive) {
+      // Clean up Slack-downloaded files
       try {
         console.log("cleaning up temp file:", tempFilePath);
         await Deno.remove(tempFilePath);
@@ -190,6 +203,23 @@ export async function transcribeAudioFile({
         }
       } catch (cleanupError) {
         console.log("Error cleaning up temp file:", cleanupError instanceof Error ? cleanupError.message : String(cleanupError));
+      }
+    } else if (tempFilePath && isGoogleDrive) {
+      // Clean up Google Drive downloaded files
+      try {
+        console.log("cleaning up Google Drive temp file:", tempFilePath);
+        await Deno.remove(tempFilePath);
+        const tempDir = tempFilePath.substring(
+          0,
+          tempFilePath.lastIndexOf("/"),
+        );
+        try {
+          await Deno.remove(tempDir);
+        } catch {
+          // Ignore error if directory is not empty or doesn't exist
+        }
+      } catch (cleanupError) {
+        console.log("Error cleaning up Google Drive temp file:", cleanupError instanceof Error ? cleanupError.message : String(cleanupError));
       }
     }
   }

--- a/supabase/functions/scribe-bot/utils.ts
+++ b/supabase/functions/scribe-bot/utils.ts
@@ -1,4 +1,5 @@
 import { TranscriptionOptions, WordItem, Sentence, SpeakerUtterance } from "./types.ts";
+import { isGoogleDriveUrl, parseGoogleDriveUrl } from "./googledrive.ts";
 
 export const parseTranscriptionOptions = (text: string = ""): TranscriptionOptions => {
   const diarize = !text.includes("--no-diarize");
@@ -132,4 +133,10 @@ export const groupBySpeaker = (words: WordItem[]): SpeakerUtterance[] => {
   }
 
   return conversation;
+};
+
+export const extractGoogleDriveUrls = (text: string): string[] => {
+  const urlPattern = /https?:\/\/[^\s<>]+/gi;
+  const urls = text.match(urlPattern) || [];
+  return urls.filter(url => isGoogleDriveUrl(url));
 };


### PR DESCRIPTION
## Summary
- ✨ Added Google Drive integration for video/audio transcription
- 🔐 Implemented service account authentication with optional domain-wide delegation
- 📁 Support for both public and organization-restricted files

## What's Changed
- Created new `googledrive.ts` module for Google Drive API integration
- Updated main handler to detect and process Google Drive URLs
- Modified transcription flow to handle both Slack uploads and Google Drive links
- Added necessary environment variables and documentation

## Configuration Required
1. **Service Account Setup**:
   - Set `GOOGLE_SERVICE_ACCOUNT_KEY` with your service account JSON
   
2. **For Organization Files** (optional):
   - Configure domain-wide delegation in Google Workspace Admin Console
   - Set `GOOGLE_IMPERSONATE_EMAIL` with a user email from your organization

## Usage
Mention the bot with a Google Drive link:
```
@文字起こしKUN https://drive.google.com/file/d/xxxxx/view --num-speakers 3
```

## Test Plan
- [x] Tested with public Google Drive files
- [x] Tested with organization-restricted files (with domain-wide delegation)
- [x] Verified existing Slack file upload functionality still works
- [x] Confirmed all transcription options work with Google Drive files

🤖 Generated with [Claude Code](https://claude.ai/code)